### PR TITLE
Updated to support more domains

### DIFF
--- a/general/users/build-create-mailbox.ps1
+++ b/general/users/build-create-mailbox.ps1
@@ -8,7 +8,8 @@ add-pssnapin Microsoft.Exchange.Management.PowerShell.E2010
 ## Query for AD accounts
 # Below commands queries the top level OU for the company you created and then outputs the details into a CSV
 $toplevelOU = Read-Host ("What is the company OU?")
-Get-ADUser -Filter * -SearchBase "OU=$toplevelOU,DC=$env:USERDOMAIN,DC=local" | `
+$OUlookup = Get-ADOrganizationalUnit -Filter 'Name -eq $toplevelOU'
+Get-ADUser -Filter * -SearchBase $OUlookup.DistinguishedName | `
 Select Name,SamAccountName,UserPrincipalName | `
 Export-Csv -Path $env:tmp\output.csv -NoTypeInformation
 


### PR DESCRIPTION
The previous script was working on the basis that the domain was (OU).domain.local which in the setup for new labs is incorrect, since these are using (OU).domain.exclaimersupport.com. This new command does an additional check to find the completed distinguished name and then uses that with the rest of the command script.

Tested this on my own lab and confirmed this works. Credit to Mr.Norris for some of the syntax here as without him this would've been a lot messier looking to split the results of this out.