### PR TITLE
Nc 24 june 2026

### DIFF
--- a/AddInChecks.ps1
+++ b/AddInChecks.ps1
@@ -1640,77 +1640,53 @@ if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Ou
 
 # --- Function: Check for Exchange Online Module ---
 function CheckExchangeOnlineModule {
-    $allowedVersions = @([Version]"3.6.0", [Version]"3.9.0")
-    $installVersion  = "3.9.0"
+    if (Get-Module -ListAvailable -Name ExchangeOnlineManagement) {
+        Write-Host "✅ Exchange Online Management module is already installed." -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "⚙️  Exchange Online Management module not found." -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "ℹ️  The installation requires the NuGet provider and PowerShell Gallery access." -ForegroundColor Cyan
+        Write-Host "    You may see prompts asking to install NuGet or trust the PowerShell Gallery — please answer 'Y' when prompted." -ForegroundColor Cyan
+        Write-Host ""
 
-    $installedModule = Get-Module -ListAvailable -Name ExchangeOnlineManagement |
-                       Sort-Object Version -Descending |
-                       Select-Object -First 1
+        $installChoice = Read-Host "Would you like to install it now? (Y/N)"
+        if ($installChoice.ToUpper() -eq "Y") {
+            try {
+                Write-Host "`n📦 Preparing to install prerequisites..." -ForegroundColor Cyan
 
-    if ($installedModule) {
-        if ($installedModule.Version -in $allowedVersions) {
-            Write-Host "✅ Exchange Online Management module v$($installedModule.Version) is already installed." -ForegroundColor Green
-            return $true
-        } elseif ($installedModule.Version -gt ($allowedVersions | Sort-Object -Descending | Select-Object -First 1)) {
-            Write-Host "⚠️  Exchange Online Management module v$($installedModule.Version) is installed, but a supported version (3.6.0 or 3.9.0) is required due to a known sign-in issue on later versions." -ForegroundColor Yellow
-            Write-Host ""
+                # --- Ensure NuGet provider is installed ---
+                if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
+                    Write-Host "🔧 Installing NuGet provider..." -ForegroundColor Cyan
+                    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false | Out-Null
+                }
 
-            $downgradeChoice = Read-Host "Would you like to install v$installVersion alongside it now? (Y/N)"
-            if ($downgradeChoice.ToUpper() -ne "Y") {
-                Write-Host "⚠️ Skipping. The script may fail to authenticate with the installed version." -ForegroundColor Yellow
-                Add-Content $FullLogFilePath "<p class='warning'>User skipped ExchangeOnlineManagement version fix. Installed: v$($installedModule.Version). Supported: 3.6.0 or 3.9.0. Authentication may fail.</p>"
+                # --- Ensure PowerShell Gallery is trusted ---
+                $galleryTrusted = (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue).InstallationPolicy
+                if ($galleryTrusted -ne 'Trusted') {
+                    Write-Host "🔒 Trusting PowerShell Gallery repository..." -ForegroundColor Cyan
+                    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
+                }
+
+                # --- Install pinned version to avoid known sign-in issue on later versions ---
+                Write-Host "📦 Installing Exchange Online Management module v3.6.0..." -ForegroundColor Cyan
+                Install-Module ExchangeOnlineManagement -RequiredVersion 3.6.0 -Force -Scope CurrentUser -AllowClobber
+
+                Write-Host "✅ Installation completed successfully!" -ForegroundColor Green
+                return $true
+
+            } catch {
+                Write-Host "❌ Failed to install the module: $($_.Exception.Message)" -ForegroundColor Red
+                Add-Content $FullLogFilePath "<p class='warning'>Exchange Online Management module installation failed: $([System.Web.HttpUtility]::HtmlEncode($_.Exception.Message))</p>"
                 return $false
             }
         } else {
-            # Older than both allowed versions — fall through to install
-            Write-Host "⚠️  Exchange Online Management module v$($installedModule.Version) is installed, but a supported version (3.6.0 or 3.9.0) is required." -ForegroundColor Yellow
-        }
-    } else {
-        Write-Host "⚙️  Exchange Online Management module not found." -ForegroundColor Yellow
-    }
-
-    Write-Host ""
-    Write-Host "ℹ️  The installation requires the NuGet provider and PowerShell Gallery access." -ForegroundColor Cyan
-    Write-Host "    You may see prompts asking to install NuGet or trust the PowerShell Gallery — please answer 'Y' when prompted." -ForegroundColor Cyan
-    Write-Host ""
-
-    $installChoice = Read-Host "Would you like to install v$installVersion now? (Y/N)"
-    if ($installChoice.ToUpper() -eq "Y") {
-        try {
-            Write-Host "`n📦 Preparing to install prerequisites..." -ForegroundColor Cyan
-
-            # --- Ensure NuGet provider is installed ---
-            if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
-                Write-Host "🔧 Installing NuGet provider..." -ForegroundColor Cyan
-                Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false | Out-Null
-            }
-
-            # --- Ensure PowerShell Gallery is trusted ---
-            $galleryTrusted = (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue).InstallationPolicy
-            if ($galleryTrusted -ne 'Trusted') {
-                Write-Host "🔒 Trusting PowerShell Gallery repository..." -ForegroundColor Cyan
-                Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
-            }
-
-            # --- Install the supported version ---
-            Write-Host "📦 Installing Exchange Online Management module v$installVersion..." -ForegroundColor Cyan
-            Install-Module ExchangeOnlineManagement -RequiredVersion $installVersion -Force -Scope CurrentUser -AllowClobber
-
-            Write-Host "✅ Installation completed successfully!" -ForegroundColor Green
-            return $true
-
-        } catch {
-            Write-Host "❌ Failed to install the module: $($_.Exception.Message)" -ForegroundColor Red
-            Add-Content $FullLogFilePath "<p class='warning'>Exchange Online Management module installation failed: $([System.Web.HttpUtility]::HtmlEncode($_.Exception.Message))</p>"
+            Write-Host "⚠️ Skipping module installation. Admin access required for automated mailbox queries." -ForegroundColor Yellow
+            Add-Content $FullLogFilePath "<p class='warning'>User skipped Exchange Online module installation. Manual Add-in version collection required.</p>"
             return $false
         }
-    } else {
-        Write-Host "⚠️ Skipping module installation. Admin access required for automated mailbox queries." -ForegroundColor Yellow
-        Add-Content $FullLogFilePath "<p class='warning'>User skipped Exchange Online module installation. Manual Add-in version collection required.</p>"
-        return $false
     }
 }
-
 # --- Function: Connect to Exchange Online ---
 function ConnectExchangeOnlineSession {
     try {

--- a/AddInChecks.ps1
+++ b/AddInChecks.ps1
@@ -297,7 +297,7 @@ function Get-ExclaimerUserInput {
             } while ($oChoice -notmatch '^[1-8]$')
 
             switch ($oChoice) {
-                1 { $Global:userInput.OutlookAffected = 'Classic Outlook' }
+                1 { $Global:userInput.OutlookAffected = 'Classic Outlook (Windows)' }
                 2 { $Global:userInput.OutlookAffected = 'New Outlook (Windows)' }
                 3 { $Global:userInput.OutlookAffected = 'Outlook Web (Windows)' }
                 4 { $Global:userInput.OutlookAffected = 'Outlook iOS' }
@@ -1630,51 +1630,74 @@ if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Ou
 
 # --- Function: Check for Exchange Online Module ---
 function CheckExchangeOnlineModule {
-    if (Get-Module -ListAvailable -Name ExchangeOnlineManagement) {
-        Write-Host "✅ Exchange Online Management module is already installed." -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "⚙️  Exchange Online Management module not found." -ForegroundColor Yellow
-        Write-Host ""
-        Write-Host "ℹ️  The installation requires the NuGet provider and PowerShell Gallery access." -ForegroundColor Cyan
-        Write-Host "    You may see prompts asking to install NuGet or trust the PowerShell Gallery — please answer 'Y' when prompted." -ForegroundColor Cyan
-        Write-Host ""
+    $allowedVersions = @([Version]"3.6.0", [Version]"3.9.0")
+    $installVersion  = "3.9.0"
 
-        $installChoice = Read-Host "Would you like to install it now? (Y/N)"
-        if ($installChoice.ToUpper() -eq "Y") {
-            try {
-                Write-Host "`n📦 Preparing to install prerequisites..." -ForegroundColor Cyan
+    $installedModule = Get-Module -ListAvailable -Name ExchangeOnlineManagement |
+                       Sort-Object Version -Descending |
+                       Select-Object -First 1
 
-                # --- Ensure NuGet provider is installed ---
-                if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
-                    Write-Host "🔧 Installing NuGet provider..." -ForegroundColor Cyan
-                    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false | Out-Null
-                }
+    if ($installedModule) {
+        if ($installedModule.Version -in $allowedVersions) {
+            Write-Host "✅ Exchange Online Management module v$($installedModule.Version) is already installed." -ForegroundColor Green
+            return $true
+        } elseif ($installedModule.Version -gt ($allowedVersions | Sort-Object -Descending | Select-Object -First 1)) {
+            Write-Host "⚠️  Exchange Online Management module v$($installedModule.Version) is installed, but a supported version (3.6.0 or 3.9.0) is required due to a known sign-in issue on later versions." -ForegroundColor Yellow
+            Write-Host ""
 
-                # --- Ensure PowerShell Gallery is trusted ---
-                $galleryTrusted = (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue).InstallationPolicy
-                if ($galleryTrusted -ne 'Trusted') {
-                    Write-Host "🔒 Trusting PowerShell Gallery repository..." -ForegroundColor Cyan
-                    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
-                }
-
-                # --- Install the Exchange Online module ---
-                Write-Host "📦 Installing Exchange Online Management module..." -ForegroundColor Cyan
-                Install-Module ExchangeOnlineManagement -Force -Scope CurrentUser -AllowClobber
-
-                Write-Host "✅ Installation completed successfully!" -ForegroundColor Green
-                return $true
-
-            } catch {
-                Write-Host "❌ Failed to install the module: $($_.Exception.Message)" -ForegroundColor Red
-                Add-Content $FullLogFilePath "<p class='warning'>Exchange Online Management module installation failed: $([System.Web.HttpUtility]::HtmlEncode($_.Exception.Message))</p>"
+            $downgradeChoice = Read-Host "Would you like to install v$installVersion alongside it now? (Y/N)"
+            if ($downgradeChoice.ToUpper() -ne "Y") {
+                Write-Host "⚠️ Skipping. The script may fail to authenticate with the installed version." -ForegroundColor Yellow
+                Add-Content $FullLogFilePath "<p class='warning'>User skipped ExchangeOnlineManagement version fix. Installed: v$($installedModule.Version). Supported: 3.6.0 or 3.9.0. Authentication may fail.</p>"
                 return $false
             }
         } else {
-            Write-Host "⚠️ Skipping module installation. Admin access required for automated mailbox queries." -ForegroundColor Yellow
-            Add-Content $FullLogFilePath "<p class='warning'>User skipped Exchange Online module installation. Manual Add-in version collection required.</p>"
+            # Older than both allowed versions — fall through to install
+            Write-Host "⚠️  Exchange Online Management module v$($installedModule.Version) is installed, but a supported version (3.6.0 or 3.9.0) is required." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "⚙️  Exchange Online Management module not found." -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "ℹ️  The installation requires the NuGet provider and PowerShell Gallery access." -ForegroundColor Cyan
+    Write-Host "    You may see prompts asking to install NuGet or trust the PowerShell Gallery — please answer 'Y' when prompted." -ForegroundColor Cyan
+    Write-Host ""
+
+    $installChoice = Read-Host "Would you like to install v$installVersion now? (Y/N)"
+    if ($installChoice.ToUpper() -eq "Y") {
+        try {
+            Write-Host "`n📦 Preparing to install prerequisites..." -ForegroundColor Cyan
+
+            # --- Ensure NuGet provider is installed ---
+            if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
+                Write-Host "🔧 Installing NuGet provider..." -ForegroundColor Cyan
+                Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false | Out-Null
+            }
+
+            # --- Ensure PowerShell Gallery is trusted ---
+            $galleryTrusted = (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue).InstallationPolicy
+            if ($galleryTrusted -ne 'Trusted') {
+                Write-Host "🔒 Trusting PowerShell Gallery repository..." -ForegroundColor Cyan
+                Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
+            }
+
+            # --- Install the supported version ---
+            Write-Host "📦 Installing Exchange Online Management module v$installVersion..." -ForegroundColor Cyan
+            Install-Module ExchangeOnlineManagement -RequiredVersion $installVersion -Force -Scope CurrentUser -AllowClobber
+
+            Write-Host "✅ Installation completed successfully!" -ForegroundColor Green
+            return $true
+
+        } catch {
+            Write-Host "❌ Failed to install the module: $($_.Exception.Message)" -ForegroundColor Red
+            Add-Content $FullLogFilePath "<p class='warning'>Exchange Online Management module installation failed: $([System.Web.HttpUtility]::HtmlEncode($_.Exception.Message))</p>"
             return $false
         }
+    } else {
+        Write-Host "⚠️ Skipping module installation. Admin access required for automated mailbox queries." -ForegroundColor Yellow
+        Add-Content $FullLogFilePath "<p class='warning'>User skipped Exchange Online module installation. Manual Add-in version collection required.</p>"
+        return $false
     }
 }
 

--- a/AddInChecks.ps1
+++ b/AddInChecks.ps1
@@ -160,6 +160,13 @@ function ConfirmElevationStatus {
     $currentUser = ($fullUser -split '\\')[-1]
     Write-Host "Current script runner: $currentUser`n" -ForegroundColor Cyan
 
+    # Get installed ExchangeOnlineManagement module version
+    $exchangeModule = Get-Module -ListAvailable -Name ExchangeOnlineManagement |
+                      Sort-Object Version -Descending |
+                      Select-Object -First 1
+    $exchangeModuleVersion = if ($exchangeModule) { $exchangeModule.Version.ToString() } else { "Not installed" }
+    Write-Host "ExchangeOnlineManagement module version: $exchangeModuleVersion`n" -ForegroundColor Cyan
+
     $isAdmin = ([Security.Principal.WindowsPrincipal] `
         [Security.Principal.WindowsIdentity]::GetCurrent()
     ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
@@ -181,6 +188,7 @@ function ConfirmElevationStatus {
             Add-Content $FullLogFilePath '<div class="section">'
             Add-Content $FullLogFilePath '<h2>🔐 Script Permission Check</h2>'
             Add-Content $FullLogFilePath "<p title=`"The user running the script in PowerShell.`"><strong>User:</strong> $currentUser</p>"
+            Add-Content $FullLogFilePath "<p><strong>ExchangeOnlineManagement Version:</strong> $exchangeModuleVersion</p>"
             Add-Content $FullLogFilePath '<p><strong>Status:</strong> Script stopped. User chose not to continue without Administrator privileges.</p>'
             Add-Content $FullLogFilePath '</div>'
 
@@ -199,11 +207,13 @@ function ConfirmElevationStatus {
     if ($isAdmin) {
         Add-Content $FullLogFilePath "<tr><td><strong>Windows User</strong></td><td title=`"The user that running the script in PowerShell.`">$currentUser</td></tr>"
         Add-Content $FullLogFilePath '<tr><td><strong>Administrator privileges</strong></td><td>Yes</td></tr>'
+        Add-Content $FullLogFilePath "<tr><td><strong>ExchangeOnlineManagement Version</strong></td><td title=`"The version of the ExchangeOnlineManagement module available on this machine.`">$exchangeModuleVersion</td></tr>"
         Add-Content $FullLogFilePath '<tr><td><strong>Impact</strong></td><td>All diagnostics can be collected.</td></tr>'
     }
     else {
         Add-Content $FullLogFilePath "<tr><td><strong>Windows User</strong></td><td title=`"The user that running the script in PowerShell.`">$currentUser</td></tr>"
         Add-Content $FullLogFilePath '<tr><td><strong>Administrator privileges</strong></td><td style="color:#F5A627;font-weight:bold;">No</td></tr>'
+        Add-Content $FullLogFilePath "<tr><td><strong>ExchangeOnlineManagement Version</strong></td><td title=`"The version of the ExchangeOnlineManagement module available on this machine.`">$exchangeModuleVersion</td></tr>"
         Add-Content $FullLogFilePath '<tr><td><strong>Impact</strong></td><td>Some diagnostics (firewall, networking, system-level logs) were skipped or limited.</td></tr>'
         Add-Content $FullLogFilePath '<tr><td><strong>User decision</strong></td><td>User chose to continue without elevation.</td></tr>'
         Add-Content $FullLogFilePath '<tr><td><strong>Recommendation</strong></td><td>Re-run the script using Run as administrator if requested by support.</td></tr>'
@@ -1630,74 +1640,51 @@ if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Ou
 
 # --- Function: Check for Exchange Online Module ---
 function CheckExchangeOnlineModule {
-    $allowedVersions = @([Version]"3.6.0", [Version]"3.9.0")
-    $installVersion  = "3.9.0"
+    if (Get-Module -ListAvailable -Name ExchangeOnlineManagement) {
+        Write-Host "✅ Exchange Online Management module is already installed." -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "⚙️  Exchange Online Management module not found." -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "ℹ️  The installation requires the NuGet provider and PowerShell Gallery access." -ForegroundColor Cyan
+        Write-Host "    You may see prompts asking to install NuGet or trust the PowerShell Gallery — please answer 'Y' when prompted." -ForegroundColor Cyan
+        Write-Host ""
 
-    $installedModule = Get-Module -ListAvailable -Name ExchangeOnlineManagement |
-                       Sort-Object Version -Descending |
-                       Select-Object -First 1
+        $installChoice = Read-Host "Would you like to install it now? (Y/N)"
+        if ($installChoice.ToUpper() -eq "Y") {
+            try {
+                Write-Host "`n📦 Preparing to install prerequisites..." -ForegroundColor Cyan
 
-    if ($installedModule) {
-        if ($installedModule.Version -in $allowedVersions) {
-            Write-Host "✅ Exchange Online Management module v$($installedModule.Version) is already installed." -ForegroundColor Green
-            return $true
-        } elseif ($installedModule.Version -gt ($allowedVersions | Sort-Object -Descending | Select-Object -First 1)) {
-            Write-Host "⚠️  Exchange Online Management module v$($installedModule.Version) is installed, but a supported version (3.6.0 or 3.9.0) is required due to a known sign-in issue on later versions." -ForegroundColor Yellow
-            Write-Host ""
+                # --- Ensure NuGet provider is installed ---
+                if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
+                    Write-Host "🔧 Installing NuGet provider..." -ForegroundColor Cyan
+                    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false | Out-Null
+                }
 
-            $downgradeChoice = Read-Host "Would you like to install v$installVersion alongside it now? (Y/N)"
-            if ($downgradeChoice.ToUpper() -ne "Y") {
-                Write-Host "⚠️ Skipping. The script may fail to authenticate with the installed version." -ForegroundColor Yellow
-                Add-Content $FullLogFilePath "<p class='warning'>User skipped ExchangeOnlineManagement version fix. Installed: v$($installedModule.Version). Supported: 3.6.0 or 3.9.0. Authentication may fail.</p>"
+                # --- Ensure PowerShell Gallery is trusted ---
+                $galleryTrusted = (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue).InstallationPolicy
+                if ($galleryTrusted -ne 'Trusted') {
+                    Write-Host "🔒 Trusting PowerShell Gallery repository..." -ForegroundColor Cyan
+                    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
+                }
+
+                # --- Install pinned version to avoid known sign-in issue on later versions ---
+                Write-Host "📦 Installing Exchange Online Management module v3.6.0..." -ForegroundColor Cyan
+                Install-Module ExchangeOnlineManagement -RequiredVersion 3.6.0 -Force -Scope CurrentUser -AllowClobber
+
+                Write-Host "✅ Installation completed successfully!" -ForegroundColor Green
+                return $true
+
+            } catch {
+                Write-Host "❌ Failed to install the module: $($_.Exception.Message)" -ForegroundColor Red
+                Add-Content $FullLogFilePath "<p class='warning'>Exchange Online Management module installation failed: $([System.Web.HttpUtility]::HtmlEncode($_.Exception.Message))</p>"
                 return $false
             }
         } else {
-            # Older than both allowed versions — fall through to install
-            Write-Host "⚠️  Exchange Online Management module v$($installedModule.Version) is installed, but a supported version (3.6.0 or 3.9.0) is required." -ForegroundColor Yellow
-        }
-    } else {
-        Write-Host "⚙️  Exchange Online Management module not found." -ForegroundColor Yellow
-    }
-
-    Write-Host ""
-    Write-Host "ℹ️  The installation requires the NuGet provider and PowerShell Gallery access." -ForegroundColor Cyan
-    Write-Host "    You may see prompts asking to install NuGet or trust the PowerShell Gallery — please answer 'Y' when prompted." -ForegroundColor Cyan
-    Write-Host ""
-
-    $installChoice = Read-Host "Would you like to install v$installVersion now? (Y/N)"
-    if ($installChoice.ToUpper() -eq "Y") {
-        try {
-            Write-Host "`n📦 Preparing to install prerequisites..." -ForegroundColor Cyan
-
-            # --- Ensure NuGet provider is installed ---
-            if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
-                Write-Host "🔧 Installing NuGet provider..." -ForegroundColor Cyan
-                Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false | Out-Null
-            }
-
-            # --- Ensure PowerShell Gallery is trusted ---
-            $galleryTrusted = (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue).InstallationPolicy
-            if ($galleryTrusted -ne 'Trusted') {
-                Write-Host "🔒 Trusting PowerShell Gallery repository..." -ForegroundColor Cyan
-                Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
-            }
-
-            # --- Install the supported version ---
-            Write-Host "📦 Installing Exchange Online Management module v$installVersion..." -ForegroundColor Cyan
-            Install-Module ExchangeOnlineManagement -RequiredVersion $installVersion -Force -Scope CurrentUser -AllowClobber
-
-            Write-Host "✅ Installation completed successfully!" -ForegroundColor Green
-            return $true
-
-        } catch {
-            Write-Host "❌ Failed to install the module: $($_.Exception.Message)" -ForegroundColor Red
-            Add-Content $FullLogFilePath "<p class='warning'>Exchange Online Management module installation failed: $([System.Web.HttpUtility]::HtmlEncode($_.Exception.Message))</p>"
+            Write-Host "⚠️ Skipping module installation. Admin access required for automated mailbox queries." -ForegroundColor Yellow
+            Add-Content $FullLogFilePath "<p class='warning'>User skipped Exchange Online module installation. Manual Add-in version collection required.</p>"
             return $false
         }
-    } else {
-        Write-Host "⚠️ Skipping module installation. Admin access required for automated mailbox queries." -ForegroundColor Yellow
-        Add-Content $FullLogFilePath "<p class='warning'>User skipped Exchange Online module installation. Manual Add-in version collection required.</p>"
-        return $false
     }
 }
 
@@ -1707,7 +1694,7 @@ function ConnectExchangeOnlineSession {
         Write-Host "`n🔗 Connecting to Exchange Online..." -ForegroundColor Cyan
         Write-Host "   You will be prompted to Sign in with Microsoft in order to continue." -ForegroundColor Yellow
         Import-Module ExchangeOnlineManagement -Force -ErrorAction Stop
-        Start-Sleep -Seconds 5
+        Start-Sleep -Seconds 3
         Connect-ExchangeOnline -ErrorAction Stop
         Write-Host "✅ Connected successfully!" -ForegroundColor Green
         return $true

--- a/AddInChecks.ps1
+++ b/AddInChecks.ps1
@@ -21,7 +21,7 @@
 #     - Network ability to test endpoints on port 443
 #
 # .VERSION
-#     1.1.0
+#     1.1.5
 #         - Collects Windows version details
 #         - Collects Outlook installation and version details
 #         - Checks for Exclaimer Cloud Add-in presence and version

--- a/AddInChecks.ps1
+++ b/AddInChecks.ps1
@@ -291,18 +291,20 @@ function Get-ExclaimerUserInput {
                 Write-Host "  4) Outlook iOS"
                 Write-Host "  5) Outlook Android"
                 Write-Host "  6) New Outlook on MacOS"
-                Write-Host "  7) Multiple / All"
-                $oChoice = Read-Host "`nEnter choice (1-7)"
-            } while ($oChoice -notmatch '^[1-7]$')
+                Write-Host "  7) Outlook Web (MacOS)"
+                Write-Host "  8) Multiple / All"
+                $oChoice = Read-Host "`nEnter choice (1-8)"
+            } while ($oChoice -notmatch '^[1-8]$')
 
             switch ($oChoice) {
                 1 { $Global:userInput.OutlookAffected = 'Classic Outlook' }
-                2 { $Global:userInput.OutlookAffected = 'New Outlook' }
-                3 { $Global:userInput.OutlookAffected = 'Outlook Web' }
+                2 { $Global:userInput.OutlookAffected = 'New Outlook (Windows)' }
+                3 { $Global:userInput.OutlookAffected = 'Outlook Web (Windows)' }
                 4 { $Global:userInput.OutlookAffected = 'Outlook iOS' }
                 5 { $Global:userInput.OutlookAffected = 'Outlook Android' }
                 6 { $Global:userInput.OutlookAffected = 'New Outlook on MacOS' }
-                7 { $Global:userInput.OutlookAffected = 'Multiple / All' }
+                7 { $Global:userInput.OutlookAffected = 'Outlook Web (MacOS)' }
+                8 { $Global:userInput.OutlookAffected = 'Multiple / All' }
             }
 
             # --- Version capture for non-Windows platforms ---
@@ -377,7 +379,7 @@ function Get-ExclaimerUserInput {
         if ($Global:userInput.Purpose -eq 'Troubleshooting') {
             Write-Host ("Users Affected:   {0}" -f $Global:userInput.UsersAffected) -ForegroundColor White
             Write-Host ("Outlook Affected: {0}" -f $Global:userInput.OutlookAffected) -ForegroundColor White
-            if ($oChoice -in @('3','4','5','6')) {
+            if ($oChoice -in @('3','4','5','6','7','8')) {
                 Write-Host ("OS / Browser:     {0}" -f $Global:userInput.OSVersion) -ForegroundColor White
                 Write-Host ("Outlook Version:  {0}" -f $Global:userInput.OutlookVersion) -ForegroundColor White
             }
@@ -402,7 +404,7 @@ function Get-ExclaimerUserInput {
             if ($Global:userInput.Purpose -eq 'Troubleshooting') {
                 Add-Content $FullLogFilePath "<tr><td><strong>Users Affected:</strong></td><td>$($Global:userInput.UsersAffected)</td></tr>"
                 Add-Content $FullLogFilePath "<tr><td><strong>Outlook Affected:</strong></td><td>$($Global:userInput.OutlookAffected)</td></tr>"
-                if ($oChoice -in @('3','4','5','6')) {
+                if ($oChoice -in @('3','4','5','6','7','8')) {
                     Add-Content $FullLogFilePath "<tr><td><strong>OS / Browser Version:</strong></td><td>$($Global:userInput.OSVersion)</td></tr>"
                     Add-Content $FullLogFilePath "<tr><td><strong>Outlook Version:</strong></td><td>$($Global:userInput.OutlookVersion)</td></tr>"
                 }
@@ -644,7 +646,7 @@ function GetWindowsVersion {
     Add-Content $FullLogFilePath '</div>'
 }
 # Only run Windows-specific checks if affected platform is Classic or New Outlook
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     GetWindowsVersion
 }
 
@@ -739,7 +741,7 @@ function GetWindowsNetworkDetails {
     Add-Content $FullLogFilePath '</table>'
     Add-Content $FullLogFilePath '</div>'
 }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     GetWindowsNetworkDetails
 }
 
@@ -1181,7 +1183,7 @@ While 32-bit applications can work with add-ins, they can use up a system's avai
     }
     
 }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     InspectOutlookConfiguration
 }
 
@@ -1324,7 +1326,7 @@ function InspectClassicOutlookEncoding {
         Add-Content $FullLogFilePath "<p class='warning'>⚠️ User hive selection was skipped. Encoding configuration could not be retrieved.</p>"
     }
 }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     # Call the function with the user's email
     InspectClassicOutlookEncoding -userEmail $Global:userInput.Email
 }
@@ -1427,7 +1429,7 @@ else {
 $webSection += '</div>'
 Add-Content -Path $FullLogFilePath -Value $webSection
 }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     InspectWordFileBlocking
 }
 
@@ -1555,7 +1557,7 @@ function InspectExclaimerCloudSignatureAgent {
             }
         }
     }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     InspectExclaimerCloudSignatureAgent
 }
 
@@ -1612,7 +1614,7 @@ Write-Host "`n========== Microsoft Edge WebView2 Runtime ==========" -Foreground
         Add-Content $FullLogFilePath "<p class='warning'>Microsoft Edge WebView2 Runtime is not installed.</p>"
     }
 }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     InspectWebView2Runtime
 }
 
@@ -2378,7 +2380,7 @@ function GetFirewallLogs {
         $Global:destination = $destination
     }
 }
-if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
     GetFirewallLogs
 }
 
@@ -2405,7 +2407,7 @@ function GetSupportSubmissionInstructions {
         "<tr><td><strong>Diagnostic report</strong></td><td>{0}</td></tr>" -f $FullLogFilePath
     )
     
-    if ($Global:userInput.OutlookAffected -in @('Classic Outlook', 'New Outlook','Outlook Web')) {
+    if ($Global:userInput.OutlookAffected -in @('Classic Outlook (Windows)', 'New Outlook (Windows)','Outlook Web (Windows)','Multiple / All')) {
         Add-Content $FullLogFilePath (
             "<tr><td><strong>Windows Firewall log</strong></td><td>{0}</td></tr>" -f ($Global:destination -or 'Not collected')
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The report now shows the installed Exchange Online Management module version during permission checks, including for non-admin runs.
  * Exchange Online setup now automatically installs required prerequisites and, when needed, installs version 3.6.0 of the module for the current user.
  * Installation outcomes are now clearly recorded in the HTML report, including failures and cases where installation is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->